### PR TITLE
Bump terraform-null-label version to 0.24.1

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 module "label" {
-  source      = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.19.2"
+  source      = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.24.1"
   namespace   = var.namespace
   stage       = var.stage
   name        = var.name
@@ -14,7 +14,7 @@ module "label" {
 }
 
 module "role_label" {
-  source      = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.19.2"
+  source      = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.24.1"
   namespace   = var.namespace
   stage       = var.stage
   name        = var.name
@@ -25,7 +25,7 @@ module "role_label" {
 }
 
 module "logs_label" {
-  source      = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.19.2"
+  source      = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.24.1"
   namespace   = var.namespace
   stage       = var.stage
   name        = var.name


### PR DESCRIPTION
Allows to use terraform version `0.15.0` and upwards.

Fixes https://github.com/masterpointio/terraform-aws-ssm-agent/issues/8