### PR TITLE
feature: bump module versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Use [the awesome `gossm` project](https://github.com/gjbae1212/gossm).
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 1.2 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.0 |
 
@@ -76,7 +76,7 @@ Use [the awesome `gossm` project](https://github.com/gjbae1212/gossm).
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.51.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0 |
 
 ## Modules
 
@@ -84,7 +84,7 @@ Use [the awesome `gossm` project](https://github.com/gjbae1212/gossm).
 |------|--------|---------|
 | <a name="module_asg_label"></a> [asg\_label](#module\_asg\_label) | cloudposse/label/null | 0.25.0 |
 | <a name="module_kms_key"></a> [kms\_key](#module\_kms\_key) | cloudposse/kms-key/aws | 0.12.1 |
-| <a name="module_logs_bucket"></a> [logs\_bucket](#module\_logs\_bucket) | cloudposse/s3-bucket/aws | 0.40.1 |
+| <a name="module_logs_bucket"></a> [logs\_bucket](#module\_logs\_bucket) | cloudposse/s3-bucket/aws | 3.1.2 |
 | <a name="module_logs_label"></a> [logs\_label](#module\_logs\_label) | cloudposse/label/null | 0.25.0 |
 | <a name="module_role_label"></a> [role\_label](#module\_role\_label) | cloudposse/label/null | 0.25.0 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |

--- a/README.md
+++ b/README.md
@@ -82,7 +82,6 @@ Use [the awesome `gossm` project](https://github.com/gjbae1212/gossm).
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_asg_label"></a> [asg\_label](#module\_asg\_label) | cloudposse/label/null | 0.25.0 |
 | <a name="module_kms_key"></a> [kms\_key](#module\_kms\_key) | cloudposse/kms-key/aws | 0.12.1 |
 | <a name="module_logs_bucket"></a> [logs\_bucket](#module\_logs\_bucket) | cloudposse/s3-bucket/aws | 3.1.2 |
 | <a name="module_logs_label"></a> [logs\_label](#module\_logs\_label) | cloudposse/label/null | 0.25.0 |

--- a/main.tf
+++ b/main.tf
@@ -1,16 +1,3 @@
-module "asg_label" {
-  source  = "cloudposse/label/null"
-  version = "0.25.0"
-
-  context = module.this.context
-
-  # This tag attribute is required.
-  # See https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_group#propagate_at_launch
-  additional_tag_map = {
-    propagate_at_launch = "true"
-  }
-}
-
 module "role_label" {
   source  = "cloudposse/label/null"
   version = "0.25.0"
@@ -331,9 +318,15 @@ resource "aws_launch_template" "default" {
 }
 
 resource "aws_autoscaling_group" "default" {
-  name_prefix = "${module.asg_label.id}-asg"
-  tags        = module.asg_label.tags_as_list_of_maps
-
+  name_prefix = "${module.this.id}-asg"
+  dynamic "tag" {
+    for_each = module.this.tags
+    content {
+      key                 = tag.key
+      value               = tag.value
+      propagate_at_launch = true
+    }
+  }
   launch_template {
     id      = aws_launch_template.default.id
     version = "$Latest"

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.13.0"
 
   required_providers {
-    aws   = ">= 3.0"
+    aws   = ">= 4.0"
     local = ">= 1.2"
     null  = ">= 2.0"
   }


### PR DESCRIPTION
## Info
This:
* Bumps S3 module to include [v3.1.2 Fix Public Bucket Creation](https://github.com/cloudposse/terraform-aws-s3-bucket/releases/tag/3.1.2).
* Removes deprecated tag argument in ASG.