### PR TITLE
Expand launch config customizations

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -276,7 +276,7 @@ resource "aws_launch_template" "default" {
   user_data     = base64encode(var.user_data)
 
   monitoring {
-    enabled = var.detailed_monitoring
+    enabled = var.monitoring_enabled
   }
 
   network_interfaces {
@@ -304,9 +304,9 @@ resource "aws_launch_template" "default" {
   }
 
   metadata_options {
-    http_endpoint = "enabled"
-    http_tokens = var.enable_imdsv2 ? "required" : "optional"
-    http_protocol_ipv6 = var.metadata_ipv6 ? "enabled" : "disabled"
+    http_endpoint      = var.metadata_http_endpoint_enabled ? "enabled" : "disabled"
+    http_tokens        = var.metadata_imdsv2_enabled ? "required" : "optional"
+    http_protocol_ipv6 = var.metadata_http_protocol_ipv6_enabled ? "enabled" : "disabled"
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -302,6 +302,12 @@ resource "aws_launch_template" "default" {
   lifecycle {
     create_before_destroy = true
   }
+
+  metadata_options {
+    http_endpoint = "enabled"
+    http_tokens = var.enable_imdsv2 ? "required" : "optional"
+    http_protocol_ipv6 = var.metadata_ipv6 ? "enabled" : "disabled"
+  }
 }
 
 resource "aws_autoscaling_group" "default" {

--- a/main.tf
+++ b/main.tf
@@ -276,11 +276,11 @@ resource "aws_launch_template" "default" {
   user_data     = base64encode(var.user_data)
 
   monitoring {
-    enabled = true
+    enabled = var.detailed_monitoring
   }
 
   network_interfaces {
-    associate_public_ip_address = false
+    associate_public_ip_address = var.associate_public_ip_address
     delete_on_termination       = true
     security_groups             = concat(var.additional_security_group_ids, [aws_security_group.default.id])
   }

--- a/variables.tf
+++ b/variables.tf
@@ -62,29 +62,38 @@ variable "additional_security_group_ids" {
   default     = []
 }
 
-variable "detailed_monitoring" {
+variable "monitoring_enabled" {
   description = "Enable detailed monitoring of instance"
-  type = bool
-  default = true
+  type        = bool
+  default     = true
 }
 
 variable "associate_public_ip_address" {
   description = "Associate public IP address"
-  type = bool
+  type        = bool
   # default should fall back to subnet setting
   default = null
 }
 
-variable "enable_imdsv2" {
-  description = "Enable IMDSv2"
-  type = bool
-  default = true
+variable "metadata_http_endpoint_enabled" {
+  description = "Whether or not to enable the metadata http endpoint"
+  type        = bool
+  default     = true
 }
 
-variable "metadata_ipv6" {
+variable "metadata_imdsv2_enabled" {
+  description = <<-EOT
+    Whether or not the metadata service requires session tokens,
+    also referred to as Instance Metadata Service Version 2 (IMDSv2).
+  EOT
+  type        = bool
+  default     = true
+}
+
+variable "metadata_http_protocol_ipv6_enabled" {
   description = "Enable IPv6 metadata endpoint"
-  type = bool
-  default = false
+  type        = bool
+  default     = false
 }
 
 ######################

--- a/variables.tf
+++ b/variables.tf
@@ -62,6 +62,19 @@ variable "additional_security_group_ids" {
   default     = []
 }
 
+variable "detailed_monitoring" {
+  description = "Enable detailed monitoring of instance"
+  type = bool
+  default = true
+}
+
+variable "associate_public_ip_address" {
+  description = "Associate public IP address"
+  type = bool
+  # default should fall back to subnet setting
+  default = null
+}
+
 ######################
 ## SESSION LOGGING ##
 ####################

--- a/variables.tf
+++ b/variables.tf
@@ -75,6 +75,18 @@ variable "associate_public_ip_address" {
   default = null
 }
 
+variable "enable_imdsv2" {
+  description = "Enable IMDSv2"
+  type = bool
+  default = true
+}
+
+variable "metadata_ipv6" {
+  description = "Enable IPv6 metadata endpoint"
+  type = bool
+  default = false
+}
+
 ######################
 ## SESSION LOGGING ##
 ####################


### PR DESCRIPTION
## what
* This allows more settings of the launch config to be customized

## why
* Allows public IP association of nodes to be configured (default: use subnet settings)
* User can disable detailed monitoring ($$)
* Customize metadata endpoint, including support for enabling IMDSv2

## references
* Added to support addressing https://github.com/masterpointio/terraform-aws-tailscale/issues/11
