### PR TITLE
fix: add ipv6 space to egress

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -132,6 +132,7 @@ resource "aws_security_group_rule" "allow_all_egress" {
   to_port           = 0
   protocol          = "-1"
   cidr_blocks       = ["0.0.0.0/0"]
+  ipv6_cidr_blocks  = ["::/0"]
   security_group_id = aws_security_group.default.id
 }
 


### PR DESCRIPTION
## what
* use `::/0` to cover the ipv6 space to allow all egress
<img width="1190" alt="image" src="https://github.com/masterpointio/terraform-aws-ssm-agent/assets/35899715/797c6d80-6a7c-4ed0-bec7-b4318756913d">

## references
* Fixes https://github.com/masterpointio/terraform-aws-ssm-agent/issues/21


