### PR TITLE
fix: instance type and architecture incompatiblity

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -13,7 +13,7 @@ data "aws_ami" "amazon_linux_2023" {
 
   filter {
     name   = "architecture"
-    values = ["x86_64"]
+    values = [var.architecture]
   }
 
   filter {

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,25 @@
+locals {
+  # Validate that only 'arm64' architecture is used with 'g' processor instances to ensure compatibility.
+  # https://docs.aws.amazon.com/ec2/latest/instancetypes/instance-type-names.html
+  is_instance_compatible = (
+    # True if does not contain 'g' when architecture is x86_64
+    (var.architecture == "x86_64" && !can(regex("g", var.instance_type))) ||
+    # True if contains 'g' when architecture is arm64
+    (var.architecture == "arm64" && can(regex("g", var.instance_type)))
+  )
+}
+
+resource "null_resource" "validate_instance_type" {
+  count = local.is_instance_compatible ? 0 : 1
+
+  lifecycle {
+    precondition {
+      condition     = local.is_instance_compatible
+      error_message = "The instance_type must be compatible with the specified architecture. For x86_64, you cannot use instance types with ARM processors (e.g., t3, m5, c5). For arm64, use instance types with 'g' indicating ARM processor (e.g., t4g, c6g, m6g)."
+    }
+  }
+}
+
 module "role_label" {
   source  = "cloudposse/label/null"
   version = "0.25.0"

--- a/main.tf
+++ b/main.tf
@@ -1,11 +1,12 @@
 locals {
+  instance_type_chars = split("", var.instance_type)
   # Validate that only 'arm64' architecture is used with 'g' processor instances to ensure compatibility.
   # https://docs.aws.amazon.com/ec2/latest/instancetypes/instance-type-names.html
   is_instance_compatible = (
-    # True if does not contain 'g' when architecture is x86_64
-    (var.architecture == "x86_64" && !can(regex("g", var.instance_type))) ||
-    # True if contains 'g' when architecture is arm64
-    (var.architecture == "arm64" && can(regex("g", var.instance_type)))
+    # True if does not contain 'g' in the third position when architecture is x86_64
+    (var.architecture == "x86_64" && element(local.instance_type_chars, 2) != "g") ||
+    # True if contains 'g' in the third position when architecture is arm64
+    (var.architecture == "arm64" && element(local.instance_type_chars, 2) == "g")
   )
 }
 

--- a/tests/main.tftest.hcl
+++ b/tests/main.tftest.hcl
@@ -1,0 +1,104 @@
+variables {
+  vpc_id = "vpc-12345678"
+  subnet_ids = ["subnet-12345678", "subnet-87654321"]
+  stage = "test"
+  namespace = "mp"
+  name = "ssm-agent"
+  region = "us-east-1"
+  availability_zones = ["us-east-1a"]
+  nat_gateway_enabled = true
+  ipv6_enabled = true
+}
+
+### TESTING INSTANCE and ARCHITECTURE COMPATIBILITY ###
+# https://docs.aws.amazon.com/ec2/latest/instancetypes/instance-type-names.html
+# https://aws.amazon.com/ec2/instance-types/
+
+# Test valid x86_64 instance type
+run "valid_x86_64_instance" {
+  command = plan
+
+  variables {
+    instance_type = "t3.micro"
+    architecture = "x86_64"
+  }
+
+  assert {
+    condition     = local.is_instance_compatible
+    error_message = "Expected instance type t3.micro to be compatible with x86_64 architecture"
+  }
+}
+
+# Test valid arm64 instance type
+run "valid_arm64_instance" {
+  command = plan
+
+  variables {
+    instance_type = "t4g.micro"
+    architecture = "arm64"
+  }
+
+  assert {
+    condition     = local.is_instance_compatible
+    error_message = "Expected instance type t4g.micro to be compatible with arm64 architecture"
+  }
+}
+
+# Test invalid x86_64 instance type (using arm64 instance type)
+run "invalid_x86_64_instance" {
+  command = plan
+
+  variables {
+    instance_type = "t4g.micro"
+    architecture = "x86_64"
+  }
+
+  expect_failures = [
+    null_resource.validate_instance_type
+  ]
+}
+
+# Test invalid arm64 instance type (using x86_64 instance type)
+run "invalid_arm64_instance" {
+  command = plan
+
+  variables {
+    instance_type = "t3.micro"
+    architecture = "arm64"
+  }
+
+  expect_failures = [
+    null_resource.validate_instance_type
+  ]
+}
+
+# Test edge case, where the 'g' is defined as the instance family rather than the processor family
+# It has 'g' in the name, but it's still an x86_64 instance type because the 'g' is the instance family
+run "graphics_instance_arm_incompatiblity_edge_case" {
+  command = plan
+
+  variables {
+    instance_type = "g3s.xlarge"
+    architecture = "arm64"
+  }
+
+  expect_failures = [
+    null_resource.validate_instance_type
+  ]
+}
+
+# Test edge case, where the 'g' is defined as the instance family rather than the processor family
+# It has 'g' in the name, but it still is compatible with x86_64 since the 'g' is the instance family
+run "graphics_instance_x86_compatibility_edge_case" {
+  command = plan
+
+  variables {
+    instance_type = "g4dn.xlarge"
+    architecture = "x86_64"
+  }
+
+  assert {
+    condition     = local.is_instance_compatible
+    error_message = "Expected instance type g3s.xlarge to be compatible with x86_64 architecture"
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -30,6 +30,12 @@ variable "ami" {
   description = "The AMI to use for the SSM Agent EC2 Instance. If not provided, the latest Amazon Linux 2023 AMI will be used. Note: This will update periodically as AWS releases updates to their AL2023 AMI. Pin to a specific AMI if you would like to avoid these updates."
 }
 
+variable "architecture" {
+  description = "The architecture of the AMI (e.g., x86_64, arm64)"
+  type        = string
+  default     = "arm64"
+}
+
 variable "user_data" {
   default     = <<EOT
 #!/bin/bash

--- a/versions.tf
+++ b/versions.tf
@@ -11,5 +11,9 @@ terraform {
       source  = "hashicorp/time"
       version = ">= 0.7"
     }
+    null = {
+      source  = "hashicorp/null"
+      version = ">= 3.2"
+    }
   }
 }


### PR DESCRIPTION
## what
* Makes the AMI architecture value a variable so it can be passed in. Default set to arm64 to be compatible with t4g.nano default, which is cheaper and seemingly more efficient compared to t3.nano.
* Maybe @Gowiem or @gberenice , you two might have more context, but looking at it and reading through, there doesn't seem like anything that requires a strict x86_64 architecture.
* I've tested by using this module with the example with different combination, and it all spins up the resources smoothly.
* Also added validation to ensure we catch this error. 

## references
* Closes #25 

