### PR TITLE
fix: Auto-detect the root device name from the AMI

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -21,3 +21,26 @@ data "aws_ami" "amazon_linux_2023" {
     values = ["hvm"]
   }
 }
+
+# A trunk-ignore rule is added here because the "owners" argument for this data resource is optional
+# (as per the Terraform provider docs) and is intentionally omitted, since the consumer of this
+# module can specify an arbitrary AMI ID as input. Therefore, the security of the AMI is a concern
+# for the consumer. According to the AWS docs, if this value is not specified, the results include
+# all images for which the caller has launch permissions.
+#
+# AWS docs: https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeImages.html.
+#
+# This rule was introduced in the following PR:
+# https://github.com/masterpointio/terraform-aws-ssm-agent/pull/43.
+#
+# trunk-ignore(trivy/AVD-AWS-0344)
+data "aws_ami" "instance" {
+  count = length(var.ami) > 0 ? 1 : 0
+
+  most_recent = true
+
+  filter {
+    name   = "image-id"
+    values = [var.ami]
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -8,6 +8,12 @@ locals {
     # True if contains 'g' in the third position when architecture is arm64
     (var.architecture == "arm64" && element(local.instance_type_chars, 2) == "g")
   )
+
+  # Get the root device name from the provided/default AMI.
+  root_volume_device_name = (
+    length(var.ami) > 0 ? element(data.aws_ami.instance, 0).root_device_name : "/dev/xvda"
+  )
+
 }
 
 resource "null_resource" "validate_instance_type" {
@@ -347,7 +353,7 @@ resource "aws_launch_template" "default" {
   }
 
   block_device_mappings {
-    device_name = "/dev/xvda"
+    device_name = local.root_volume_device_name
     ebs {
       encrypted   = true
       volume_size = var.volume_size


### PR DESCRIPTION
## what

- This PR removes the current hard-coded block device mapping configuration value and allows for automatic detection of the root device name from the provided AMI.

## why

- Currently, the block device configuration has the "/dev/xvda" root device name hard-coded. Although this setting is true for newer images, some AMIs use different device names (e.g. Ubuntu often uses "/dev/sda1".
- This PR fixes the "incompatibility" of the "ami" variable and this hard-coded setting. For example, if anyone provides an Ubuntu AMI, this leads to AWS autoscaling group being "stuck" and instances won't spawn, with the following error:

```
Launching a new EC2 instance. Status Reason: The request must contain the parameter size or snapshotId. Launching EC2 instance failed.
```

## references

- https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/block-device-mapping-concepts.html
- https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/device_naming.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The root volume device name is now set dynamically based on the selected AMI, allowing for compatibility with custom AMIs.
- **Improvements**
  - Enhanced flexibility when specifying a custom AMI by automatically adjusting the root device name in launch templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->