### PR TITLE
fix: update compability tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ aws ssm start-session \
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_kms_key"></a> [kms\_key](#module\_kms\_key) | cloudposse/kms-key/aws | 0.12.1 |
+| <a name="module_kms_key"></a> [kms\_key](#module\_kms\_key) | cloudposse/kms-key/aws | 0.12.2 |
 | <a name="module_logs_bucket"></a> [logs\_bucket](#module\_logs\_bucket) | cloudposse/s3-bucket/aws | 4.10.0 |
 | <a name="module_logs_label"></a> [logs\_label](#module\_logs\_label) | cloudposse/label/null | 0.25.0 |
 | <a name="module_role_label"></a> [role\_label](#module\_role\_label) | cloudposse/label/null | 0.25.0 |

--- a/tests/cpu-compatibility.tftest.hcl
+++ b/tests/cpu-compatibility.tftest.hcl
@@ -21,6 +21,13 @@ run "valid_x86_64_instance" {
   variables {
     instance_type = "t3.micro"
     architecture  = "x86_64"
+    user_data     = <<-EOT
+      #!/bin/bash
+      cd /tmp
+      sudo yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm
+      sudo systemctl enable amazon-ssm-agent
+      sudo systemctl start amazon-ssm-agent
+    EOT
   }
 
   assert {
@@ -54,7 +61,7 @@ run "invalid_x86_64_instance" {
   }
 
   expect_failures = [
-    null_resource.validate_instance_type
+    terraform_data.validate_configuration
   ]
 }
 
@@ -68,7 +75,7 @@ run "invalid_arm64_instance" {
   }
 
   expect_failures = [
-    null_resource.validate_instance_type
+    terraform_data.validate_configuration
   ]
 }
 
@@ -83,7 +90,7 @@ run "graphics_instance_arm_incompatiblity_edge_case" {
   }
 
   expect_failures = [
-    null_resource.validate_instance_type
+    terraform_data.validate_configuration
   ]
 }
 
@@ -95,10 +102,147 @@ run "graphics_instance_x86_compatibility_edge_case" {
   variables {
     instance_type = "g4dn.xlarge"
     architecture  = "x86_64"
+    user_data     = <<-EOT
+      #!/bin/bash
+      cd /tmp
+      sudo yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm
+      sudo systemctl enable amazon-ssm-agent
+      sudo systemctl start amazon-ssm-agent
+    EOT
   }
 
   assert {
     condition     = local.is_instance_compatible
-    error_message = "Expected instance type g3s.xlarge to be compatible with x86_64 architecture"
+    error_message = "Expected instance type g4dn.xlarge to be compatible with x86_64 architecture"
+  }
+}
+
+### TESTING USER_DATA and ARCHITECTURE COMPATIBILITY ###
+
+# Test valid: arm64 architecture with arm64 user_data
+run "valid_arm64_userdata_with_arm64_arch" {
+  command = plan
+
+  variables {
+    instance_type = "t4g.micro"
+    architecture  = "arm64"
+    user_data     = <<-EOT
+      #!/bin/bash
+      cd /tmp
+      sudo yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_arm64/amazon-ssm-agent.rpm
+      sudo systemctl enable amazon-ssm-agent
+      sudo systemctl start amazon-ssm-agent
+    EOT
+  }
+
+  assert {
+    condition     = local.is_fully_compatible
+    error_message = "Expected arm64 user_data to be compatible with arm64 architecture"
+  }
+}
+
+# Test valid: x86_64 architecture with amd64 user_data
+run "valid_amd64_userdata_with_x86_64_arch" {
+  command = plan
+
+  variables {
+    instance_type = "t3.micro"
+    architecture  = "x86_64"
+    user_data     = <<-EOT
+      #!/bin/bash
+      cd /tmp
+      sudo yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm
+      sudo systemctl enable amazon-ssm-agent
+      sudo systemctl start amazon-ssm-agent
+    EOT
+  }
+
+  assert {
+    condition     = local.is_fully_compatible
+    error_message = "Expected amd64 user_data to be compatible with x86_64 architecture"
+  }
+}
+
+# Test invalid: x86_64 architecture with arm64 user_data (mismatched)
+run "invalid_arm64_userdata_with_x86_64_arch" {
+  command = plan
+
+  variables {
+    instance_type = "t3.micro"
+    architecture  = "x86_64"
+    user_data     = <<-EOT
+      #!/bin/bash
+      cd /tmp
+      sudo yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_arm64/amazon-ssm-agent.rpm
+      sudo systemctl enable amazon-ssm-agent
+      sudo systemctl start amazon-ssm-agent
+    EOT
+  }
+
+  expect_failures = [
+    terraform_data.validate_configuration
+  ]
+}
+
+# Test invalid: arm64 architecture with amd64 user_data (mismatched)
+run "invalid_amd64_userdata_with_arm64_arch" {
+  command = plan
+
+  variables {
+    instance_type = "t4g.micro"
+    architecture  = "arm64"
+    user_data     = <<-EOT
+      #!/bin/bash
+      cd /tmp
+      sudo yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm
+      sudo systemctl enable amazon-ssm-agent
+      sudo systemctl start amazon-ssm-agent
+    EOT
+  }
+
+  expect_failures = [
+    terraform_data.validate_configuration
+  ]
+}
+
+# Test valid: architecture-neutral user_data works with arm64
+run "valid_neutral_userdata_with_arm64_arch" {
+  command = plan
+
+  variables {
+    instance_type = "t4g.micro"
+    architecture  = "arm64"
+    user_data     = <<-EOT
+      #!/bin/bash
+      echo "Hello World"
+      sudo systemctl enable amazon-ssm-agent
+      sudo systemctl start amazon-ssm-agent
+    EOT
+  }
+
+  assert {
+    condition     = local.is_fully_compatible
+    error_message = "Expected architecture-neutral user_data to be compatible with arm64 architecture"
+  }
+}
+
+# Test valid: architecture-neutral user_data works with x86_64
+run "valid_neutral_userdata_with_x86_64_arch" {
+  command = plan
+
+  variables {
+    instance_type = "t3.micro"
+    architecture  = "x86_64"
+    user_data     = <<-EOT
+      #!/bin/bash
+      echo "Hello World"
+      sudo systemctl enable amazon-ssm-agent
+      sudo systemctl start amazon-ssm-agent
+    EOT
+  }
+
+  assert {
+    condition     = local.is_fully_compatible
+    error_message = "Expected architecture-neutral user_data to be compatible with x86_64 architecture"
   }
 }


### PR DESCRIPTION
## what

- Fixed `expect_failures` references from non-existent `null_resource.validate_instance_type` to `terraform_data.validate_configuration`
- Added x86_64-compatible `user_data` to tests using architecture = "x86_64" (default user_data contains linux_arm64)
- Added new tests for user_data/architecture compatibility validation.

## why

- After merging the PR #64,  the tests were failing due to using an outdated test GHA action that contained a bug - it pulled source code from the main branch instead of the actual PR branch being tested.

## references

- https://github.com/masterpointio/terraform-aws-ssm-agent/actions/runs/20723348656/job/59492735427
