### PR TITLE
fix(enabled=false): remove resources

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -1,9 +1,13 @@
 data "aws_region" "current" {}
 data "aws_caller_identity" "current" {}
 
+locals {
+  enabled = module.this.enabled
+}
+
 # VPC lookup by name (when vpc_name is provided)
 data "aws_vpc" "selected" {
-  count = var.vpc_name != null ? 1 : 0
+  count = local.enabled && var.vpc_name != null ? 1 : 0
 
   filter {
     name   = "tag:Name"
@@ -13,7 +17,7 @@ data "aws_vpc" "selected" {
 
 # Individual subnet lookup by name (when subnet_names are provided)
 data "aws_subnet" "selected" {
-  for_each = toset(var.subnet_names)
+  for_each = local.enabled ? toset(var.subnet_names) : toset([])
 
   filter {
     name   = "tag:Name"
@@ -27,6 +31,8 @@ data "aws_subnet" "selected" {
 
 # Most recent Amazon Linux 2023 AMI
 data "aws_ami" "amazon_linux_2023" {
+  count = local.enabled ? 1 : 0
+
   most_recent = true
   owners      = ["amazon"]
 
@@ -59,7 +65,7 @@ data "aws_ami" "amazon_linux_2023" {
 #
 # trivy:ignore:AVD-AWS-0344
 data "aws_ami" "instance" {
-  count = length(var.ami) > 0 ? 1 : 0
+  count = local.enabled && length(var.ami) > 0 ? 1 : 0
 
   most_recent = true
 

--- a/main.tf
+++ b/main.tf
@@ -23,7 +23,7 @@ locals {
 
   # Get the root device name from the provided/default AMI.
   root_volume_device_name = (
-    length(var.ami) > 0 ? element(data.aws_ami.instance, 0).root_device_name : "/dev/xvda"
+    length(var.ami) > 0 ? one(data.aws_ami.instance[*].root_device_name) : "/dev/xvda"
   )
 
   # VPC and Subnet ID resolution - names take precedence over IDs
@@ -33,6 +33,8 @@ locals {
 }
 
 resource "terraform_data" "validate_configuration" {
+  count = local.enabled ? 1 : 0
+
   lifecycle {
     precondition {
       condition     = local.is_fully_compatible
@@ -82,6 +84,8 @@ locals {
 ###################
 
 resource "aws_iam_role" "default" {
+  count = local.enabled ? 1 : 0
+
   name                 = module.role_label.id
   assume_role_policy   = data.aws_iam_policy_document.default.json
   permissions_boundary = var.permissions_boundary
@@ -89,29 +93,33 @@ resource "aws_iam_role" "default" {
 }
 
 resource "aws_iam_role_policy_attachment" "default" {
-  role       = aws_iam_role.default.name
+  count = local.enabled ? 1 : 0
+
+  role       = one(aws_iam_role.default[*].name)
   policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
 }
 
 resource "aws_iam_role_policy" "session_logging" {
-  count = var.session_logging_enabled ? 1 : 0
+  count = local.enabled && var.session_logging_enabled ? 1 : 0
 
   name   = "${module.role_label.id}-session-logging"
-  role   = aws_iam_role.default.name
-  policy = join("", data.aws_iam_policy_document.session_logging.*.json)
+  role   = one(aws_iam_role.default[*].name)
+  policy = join("", data.aws_iam_policy_document.session_logging[*].json)
 }
 
 resource "aws_iam_role_policy" "custom" {
-  count = length(var.custom_policy_document) > 0 ? 1 : 0
+  count = local.enabled && length(var.custom_policy_document) > 0 ? 1 : 0
 
   name   = "${module.role_label.id}-${var.custom_policy_name}"
-  role   = aws_iam_role.default.name
+  role   = one(aws_iam_role.default[*].name)
   policy = var.custom_policy_document
 }
 
 resource "aws_iam_instance_profile" "default" {
+  count = local.enabled ? 1 : 0
+
   name = module.role_label.id
-  role = aws_iam_role.default.name
+  role = one(aws_iam_role.default[*].name)
 }
 
 #####################
@@ -119,6 +127,8 @@ resource "aws_iam_instance_profile" "default" {
 ###################
 
 resource "aws_security_group" "default" {
+  count = local.enabled ? 1 : 0
+
   vpc_id      = local.vpc_id
   name        = module.this.id
   description = "Allow ALL egress from SSM Agent."
@@ -127,6 +137,8 @@ resource "aws_security_group" "default" {
 
 # trivy:ignore:aws-vpc-no-public-egress-sgr SSM Agent requires broad egress to communicate with AWS services
 resource "aws_security_group_rule" "allow_all_egress" {
+  count = local.enabled ? 1 : 0
+
   type              = "egress"
   from_port         = 0
   to_port           = 0
@@ -134,11 +146,11 @@ resource "aws_security_group_rule" "allow_all_egress" {
   cidr_blocks       = ["0.0.0.0/0"]
   ipv6_cidr_blocks  = ["::/0"]
   description       = "Allow all outbound traffic for SSM Agent communication with AWS services"
-  security_group_id = aws_security_group.default.id
+  security_group_id = one(aws_security_group.default[*].id)
 }
 
 resource "aws_security_group_rule" "additional" {
-  for_each = var.additional_security_group_rules
+  for_each = local.enabled ? var.additional_security_group_rules : {}
 
   type      = lookup(each.value, "type")
   from_port = lookup(each.value, "from_port")
@@ -151,7 +163,7 @@ resource "aws_security_group_rule" "additional" {
   prefix_list_ids  = lookup(each.value, "prefix_list_ids", null)
   self             = lookup(each.value, "self", null)
 
-  security_group_id = aws_security_group.default.id
+  security_group_id = one(aws_security_group.default[*].id)
 }
 
 #######################
@@ -162,7 +174,7 @@ module "kms_key" {
   source  = "cloudposse/kms-key/aws"
   version = "0.12.2"
 
-  enabled = var.session_logging_enabled && var.session_logging_encryption_enabled && length(var.session_logging_kms_key_arn) == 0
+  enabled = local.enabled && var.session_logging_enabled && var.session_logging_encryption_enabled && length(var.session_logging_kms_key_arn) == 0
   context = module.logs_label.context
 
   description             = "KMS key for encrypting Session Logs in S3 and CloudWatch."
@@ -212,7 +224,7 @@ module "logs_bucket" {
   source  = "cloudposse/s3-bucket/aws"
   version = "4.10.0"
 
-  enabled = local.logs_bucket_enabled
+  enabled = local.logs_bucket_enabled && module.this.enabled
   context = module.logs_label.context
 
   # Encryption / Security
@@ -246,7 +258,7 @@ module "logs_bucket" {
 }
 
 resource "aws_cloudwatch_log_group" "session_logging" {
-  count = var.session_logging_enabled ? 1 : 0
+  count = local.enabled && var.session_logging_enabled ? 1 : 0
 
   name              = module.logs_label.id
   retention_in_days = var.cloudwatch_retention_in_days
@@ -255,7 +267,7 @@ resource "aws_cloudwatch_log_group" "session_logging" {
 }
 
 resource "aws_ssm_document" "session_logging" {
-  count = var.session_logging_enabled && var.create_run_shell_document ? 1 : 0
+  count = local.enabled && var.session_logging_enabled && var.create_run_shell_document ? 1 : 0
 
   name          = var.session_logging_ssm_document_name
   document_type = "Session"
@@ -284,8 +296,10 @@ DOC
 ##########################
 
 resource "aws_launch_template" "default" {
+  count = local.enabled ? 1 : 0
+
   name_prefix   = module.this.id
-  image_id      = coalesce(var.ami, data.aws_ami.amazon_linux_2023.id)
+  image_id      = coalesce(var.ami, one(data.aws_ami.amazon_linux_2023[*].id))
   instance_type = var.instance_type
   key_name      = var.key_pair_name
   user_data     = base64encode(var.user_data)
@@ -299,11 +313,11 @@ resource "aws_launch_template" "default" {
   network_interfaces {
     associate_public_ip_address = var.associate_public_ip_address
     delete_on_termination       = true
-    security_groups             = concat(var.additional_security_group_ids, [aws_security_group.default.id])
+    security_groups             = concat(var.additional_security_group_ids, aws_security_group.default[*].id)
   }
 
   iam_instance_profile {
-    name = aws_iam_instance_profile.default.name
+    name = one(aws_iam_instance_profile.default[*].name)
   }
 
   tag_specifications {
@@ -336,6 +350,8 @@ resource "aws_launch_template" "default" {
 }
 
 resource "aws_autoscaling_group" "default" {
+  count = local.enabled ? 1 : 0
+
   name_prefix = "${module.this.id}-asg"
 
   max_size         = var.max_size
@@ -356,8 +372,8 @@ resource "aws_autoscaling_group" "default" {
   ]
 
   launch_template {
-    id      = aws_launch_template.default.id
-    version = aws_launch_template.default.latest_version
+    id      = one(aws_launch_template.default[*].id)
+    version = one(aws_launch_template.default[*].latest_version)
   }
 
   instance_refresh {

--- a/moved.tf
+++ b/moved.tf
@@ -1,0 +1,42 @@
+# Moved blocks for resources that will have count added
+# These handle state migration when adding count = module.this.enabled ? 1 : 0
+
+moved {
+  from = aws_iam_role.default
+  to   = aws_iam_role.default[0]
+}
+
+moved {
+  from = aws_iam_role_policy_attachment.default
+  to   = aws_iam_role_policy_attachment.default[0]
+}
+
+moved {
+  from = aws_iam_instance_profile.default
+  to   = aws_iam_instance_profile.default[0]
+}
+
+moved {
+  from = aws_security_group.default
+  to   = aws_security_group.default[0]
+}
+
+moved {
+  from = aws_security_group_rule.allow_all_egress
+  to   = aws_security_group_rule.allow_all_egress[0]
+}
+
+moved {
+  from = aws_launch_template.default
+  to   = aws_launch_template.default[0]
+}
+
+moved {
+  from = aws_autoscaling_group.default
+  to   = aws_autoscaling_group.default[0]
+}
+
+moved {
+  from = terraform_data.vpc_subnet_validation
+  to   = terraform_data.vpc_subnet_validation[0]
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -4,31 +4,31 @@ output "instance_name" {
 }
 
 output "security_group_id" {
-  value       = aws_security_group.default.id
+  value       = one(aws_security_group.default[*].id)
   description = "The ID of the SSM Agent Security Group."
 }
 
 output "launch_template_id" {
-  value       = aws_launch_template.default.id
+  value       = one(aws_launch_template.default[*].id)
   description = "The ID of the SSM Agent Launch Template."
 }
 
 output "autoscaling_group_id" {
-  value       = aws_autoscaling_group.default.id
+  value       = one(aws_autoscaling_group.default[*].id)
   description = "The ID of the SSM Agent Autoscaling Group."
 }
 
 output "role_id" {
-  value       = aws_iam_role.default.id
+  value       = one(aws_iam_role.default[*].id)
   description = "The ID of the SSM Agent Role."
 }
 
 output "session_logging_bucket_id" {
-  value       = var.session_logging_enabled ? local.session_logging_bucket_name : ""
+  value       = local.enabled && var.session_logging_enabled ? local.session_logging_bucket_name : ""
   description = "The ID of the SSM Agent Session Logging S3 Bucket."
 }
 
 output "session_logging_bucket_arn" {
-  value       = local.session_logging_bucket_arn
+  value       = local.enabled ? local.session_logging_bucket_arn : ""
   description = "The ARN of the SSM Agent Session Logging S3 Bucket."
 }

--- a/validations.tf
+++ b/validations.tf
@@ -1,5 +1,7 @@
 # Validation using terraform_data to halt execution if requirements aren't met
 resource "terraform_data" "vpc_subnet_validation" {
+  count = local.enabled ? 1 : 0
+
   lifecycle {
     precondition {
       condition     = var.vpc_name != null || var.vpc_id != null
@@ -14,14 +16,15 @@ resource "terraform_data" "vpc_subnet_validation" {
 }
 
 # Warning checks for VPC and subnet configuration (non-blocking)
+# Note: check blocks don't support count, so conditions include enabled check
 check "vpc_subnet_warnings" {
   assert {
-    condition     = !(var.vpc_name != null && var.vpc_id != null)
+    condition     = !local.enabled || !(var.vpc_name != null && var.vpc_id != null)
     error_message = "Both vpc_name and vpc_id are provided. When vpc_name is specified, vpc_id will be ignored."
   }
 
   assert {
-    condition     = !(length(var.subnet_names) > 0 && length(var.subnet_ids) > 0)
+    condition     = !local.enabled || !(length(var.subnet_names) > 0 && length(var.subnet_ids) > 0)
     error_message = "Both subnet_names and subnet_ids are provided. When subnet_names are specified, subnet_ids will be ignored."
   }
 }


### PR DESCRIPTION
## what

- migrate resources to be removed when enabled is set to `false`

## why

- expected behavior
- while tofu supports lifecycle flags, this maintains broader support for those not on the latest tofu release

## references

- [internal discussion](https://masterpoint.slack.com/archives/C09EEC4GW6L/p1770243968224769)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added conditional enablement control for module components, allowing optional deployment based on configuration.

* **Refactor**
  * Restructured resource dependencies for improved consistency and conditional resource management.

* **Chores**
  * Implemented state migration support for existing deployments to ensure seamless upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->