### PR TITLE
fix: pin GitHub Actions to commit SHAs (INT-326)

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Trunk Check
         uses: trunk-io/trunk-action@75699af9e26881e564e9d832ef7dc3af25ec031b # v1.2.4
         env:

--- a/.github/workflows/trunk-upgrade.yaml
+++ b/.github/workflows/trunk-upgrade.yaml
@@ -17,7 +17,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Run Trunk Upgrade
         uses: masterpointio/github-action-trunk-upgrade@5829528076cea6cedbba2f3b77734034295724db # v0.1.1


### PR DESCRIPTION
## Info

- Pins all `uses:` references in GitHub Actions workflows to full commit SHAs.

## References

- https://docs.github.com/en/actions/reference/security/secure-use#using-third-party-actions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow dependencies to latest compatible versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->